### PR TITLE
Adds extrapolation for all Weyl scalars.

### DIFF
--- a/Code/GWFrames/Extrapolation.py
+++ b/Code/GWFrames/Extrapolation.py
@@ -158,10 +158,10 @@ def ReadFiniteRadiusWaveform(n, filename, WaveformName, ChMass, InitialAdmEnergy
             UnitScaleFactor = 1.0 / ChMass
             RadiusRatio = Radii / CoordRadius**3
         elif(DataType == GWFrames.Psi1) :
-            UnitScaleFactor = 1.0
+            UnitScaleFactor = 1.0 / ChMass**2
             RadiusRatio = Radii / CoordRadius**4
         elif(DataType == GWFrames.Psi0) :
-            UnitScaleFactor = ChMass
+            UnitScaleFactor = 1.0 / ChMass**3
             RadiusRatio = Radii / CoordRadius**5
         else :
             raise ValueError('DataType "{0}" is unknown.'.format(DataType))

--- a/Code/GWFrames/Extrapolation.py
+++ b/Code/GWFrames/Extrapolation.py
@@ -139,15 +139,32 @@ def ReadFiniteRadiusWaveform(n, filename, WaveformName, ChMass, InitialAdmEnergy
         Ws[n].SetMIsScaledOut(True) # We have made this true
         Ws[n].SetLM(LM)
         Data = empty((NModes, NTimes), dtype='complex')
+
+        RadiusRatio = Radii / CoordRadius
+
         if(DataType == GWFrames.h) :
             UnitScaleFactor = 1.0 / ChMass
+            RadiusRatio = Radii / CoordRadius
         elif(DataType == GWFrames.hdot) :
             UnitScaleFactor = 1.0
+            RadiusRatio = Radii / CoordRadius
         elif(DataType == GWFrames.Psi4) :
             UnitScaleFactor = ChMass
+            RadiusRatio = Radii / CoordRadius
+        elif(DataType == GWFrames.Psi3) :
+            UnitScaleFactor = 1.0
+            RadiusRatio = Radii / CoordRadius**2
+        elif(DataType == GWFrames.Psi2) :
+            UnitScaleFactor = 1.0 / ChMass
+            RadiusRatio = Radii / CoordRadius**3
+        elif(DataType == GWFrames.Psi1) :
+            UnitScaleFactor = 1.0
+            RadiusRatio = Radii / CoordRadius**4
+        elif(DataType == GWFrames.Psi0) :
+            UnitScaleFactor = ChMass
+            RadiusRatio = Radii / CoordRadius**5
         else :
             raise ValueError('DataType "{0}" is unknown.'.format(DataType))
-        RadiusRatio = Radii / CoordRadius
         for m,DataSet in enumerate(YLMdata) :
             modedata = array(W[DataSet])
             Data[m,:] = (modedata[Indices,1] + 1j*modedata[Indices,2]) * RadiusRatio * UnitScaleFactor
@@ -204,9 +221,17 @@ def ReadFiniteRadiusData(ChMass=0.0, filename='rh_FiniteRadii_CodeUnits.h5', Coo
             DataType = GWFrames.h
         elif('psi4' in DataType.lower()) :
             DataType = GWFrames.Psi4
+        elif('psi3' in DataType.lower()) :
+            DataType = GWFrames.Psi3
+        elif('psi2' in DataType.lower()) :
+            DataType = GWFrames.Psi2
+        elif('psi1' in DataType.lower()) :
+            DataType = GWFrames.Psi1
+        elif('psi0' in DataType.lower()) :
+            DataType = GWFrames.Psi0
         else :
             DataType = GWFrames.UnknownDataType
-            raise ValueError("The file '{0}' does not contain a recognizable description of the data type ('h', 'hdot', or 'Psi4').".format(filename))
+            raise ValueError("The file '{0}' does not contain a recognizable description of the data type ('h', 'hdot', 'Psi4', 'Psi3', 'Psi2', 'Psi1', or 'Psi0').".format(filename))
         PrintedLine = ''
         for n in range(NWaveforms) :
             if(n==NWaveforms-1) :
@@ -738,6 +763,14 @@ def FindPossibleExtrapolationsToRun(TopLevelInputDir) :
                     SubdirectoriesAndDataFiles.append([step[0].replace(TopLevelInputDir+'/',''), 'rh_FiniteRadii_CodeUnits.h5'])
                 if('rPsi4_FiniteRadii_CodeUnits.h5' in step[2]) :
                     SubdirectoriesAndDataFiles.append([step[0].replace(TopLevelInputDir+'/',''), 'rPsi4_FiniteRadii_CodeUnits.h5'])
+                if('r2Psi3_FiniteRadii_CodeUnits.h5' in step[2]) :
+                    SubdirectoriesAndDataFiles.append([step[0].replace(TopLevelInputDir+'/',''), 'r2Psi3_FiniteRadii_CodeUnits.h5'])
+                if('r3Psi2_FiniteRadii_CodeUnits.h5' in step[2]) :
+                    SubdirectoriesAndDataFiles.append([step[0].replace(TopLevelInputDir+'/',''), 'r3Psi2_FiniteRadii_CodeUnits.h5'])
+                if('r4Psi1_FiniteRadii_CodeUnits.h5' in step[2]) :
+                    SubdirectoriesAndDataFiles.append([step[0].replace(TopLevelInputDir+'/',''), 'r4Psi1_FiniteRadii_CodeUnits.h5'])
+                if('r5Psi0_FiniteRadii_CodeUnits.h5' in step[2]) :
+                    SubdirectoriesAndDataFiles.append([step[0].replace(TopLevelInputDir+'/',''), 'r5Psi0_FiniteRadii_CodeUnits.h5'])
     return SubdirectoriesAndDataFiles
 
 def RunExtrapolation(TopLevelInputDir, TopLevelOutputDir, Subdirectory, DataFile, Template) :

--- a/Code/SWIG/Extensions.py
+++ b/Code/SWIG/Extensions.py
@@ -190,10 +190,14 @@ def GetLaTeXDataDescription(W) :
     if(W.MIsScaledOut()) :
         if(W.DataType()==UnknownDataType or W.DataType()==h or W.DataType()==Psi2) :
             LaTeXDataDescription = LaTeXDataDescription + W.DataTypeLaTeXString() + r'/M'
-        elif(W.DataType()==hdot or W.DataType()==Psi3 or W.DataType()==Psi1) :
+        elif(W.DataType()==hdot or W.DataType()==Psi3) :
             LaTeXDataDescription = LaTeXDataDescription + W.DataTypeLaTeXString() # hdot is independent of M
-        elif(W.DataType()==Psi4 or W.DataType()==Psi0) :
+        elif(W.DataType()==Psi4) :
             LaTeXDataDescription = LaTeXDataDescription + r'M\,' + W.DataTypeLaTeXString()
+        elif(W.DataType()==Psi1) :
+            LaTeXDataDescription = LaTeXDataDescription + W.DataTypeLaTeXString() + r'/M$^2$'
+        elif(W.DataType()==Psi0) :
+            LaTeXDataDescription = LaTeXDataDescription + W.DataTypeLaTeXString() + r'/M$^3$'
     else :
         LaTeXDataDescription = LaTeXDataDescription + W.DataTypeLaTeXString()
     return LaTeXDataDescription

--- a/Code/SWIG/Extensions.py
+++ b/Code/SWIG/Extensions.py
@@ -195,9 +195,9 @@ def GetLaTeXDataDescription(W) :
         elif(W.DataType()==Psi4) :
             LaTeXDataDescription = LaTeXDataDescription + r'M\,' + W.DataTypeLaTeXString()
         elif(W.DataType()==Psi1) :
-            LaTeXDataDescription = LaTeXDataDescription + W.DataTypeLaTeXString() + r'/M$^2$'
+            LaTeXDataDescription = LaTeXDataDescription + W.DataTypeLaTeXString() + r'/M^2'
         elif(W.DataType()==Psi0) :
-            LaTeXDataDescription = LaTeXDataDescription + W.DataTypeLaTeXString() + r'/M$^3$'
+            LaTeXDataDescription = LaTeXDataDescription + W.DataTypeLaTeXString() + r'/M^3'
     else :
         LaTeXDataDescription = LaTeXDataDescription + W.DataTypeLaTeXString()
     return LaTeXDataDescription

--- a/Code/SWIG/Extensions.py
+++ b/Code/SWIG/Extensions.py
@@ -183,16 +183,16 @@ Waveform.GetFileNamePrefix = GetFileNamePrefix
 PNWaveform.GetFileNamePrefix = GetFileNamePrefix
 
 def GetLaTeXDataDescription(W) :
-    from GWFrames import UnknownDataType, h, hdot, Psi4
+    from GWFrames import UnknownDataType, h, hdot, Psi4, Psi3, Psi2, Psi1, Psi0
     LaTeXDataDescription = ''
     if(W.RIsScaledOut()) :
         LaTeXDataDescription = r'r\,'
     if(W.MIsScaledOut()) :
-        if(W.DataType()==UnknownDataType or W.DataType()==h) :
+        if(W.DataType()==UnknownDataType or W.DataType()==h or W.DataType()==Psi2) :
             LaTeXDataDescription = LaTeXDataDescription + W.DataTypeLaTeXString() + r'/M'
-        elif(W.DataType()==hdot) :
+        elif(W.DataType()==hdot or W.DataType()==Psi3 or W.DataType()==Psi1) :
             LaTeXDataDescription = LaTeXDataDescription + W.DataTypeLaTeXString() # hdot is independent of M
-        elif(W.DataType()==Psi4) :
+        elif(W.DataType()==Psi4 or W.DataType()==Psi0) :
             LaTeXDataDescription = LaTeXDataDescription + r'M\,' + W.DataTypeLaTeXString()
     else :
         LaTeXDataDescription = LaTeXDataDescription + W.DataTypeLaTeXString()
@@ -435,6 +435,14 @@ def ReadFromNRAR(FileName) :
             W.SetFrameType(1)
             W.SetRIsScaledOut(True)
             W.SetMIsScaledOut(True)
+            if('psi0' in FileName.lower()) :
+                W.SetDataType(7)
+            if('psi1' in FileName.lower()) :
+                W.SetDataType(6)
+            if('psi2' in FileName.lower()) :
+                W.SetDataType(5)
+            if('psi3' in FileName.lower()) :
+                W.SetDataType(4)
             if('psi4' in FileName.lower()) :
                 W.SetDataType(3)
             elif('hdot' in FileName.lower()) :

--- a/Code/Waveforms.cpp
+++ b/Code/Waveforms.cpp
@@ -251,7 +251,7 @@ GWFrames::Waveform::Waveform(const std::string& FileName, const std::string& Dat
   cerr << "Warning: Waveform constructor assumes (ell,m) modes are stored as (2,-2), (2,-1), ...\n";
   {
     unsigned int i_m = 0;
-    for(int ell=2; ell<10000; ++ell) { // Note ridiculous upper bound on ell to insure against infinite loops
+    for(int ell=std::abs(SpinWeight()); ell<10000; ++ell) { // Note ridiculous upper bound on ell to insure against infinite loops
       for(int m=-ell; m<=ell; ++m) {
         if(i_m>=NModes) { break; }
         lm[i_m][0] = ell;
@@ -670,7 +670,7 @@ std::string GWFrames::Waveform::DescriptorString() const {
     else if(DataType()==Psi1)
       Descriptor = Descriptor + "4" + DataTypeString() + "OverM2";
     else if(DataType()==Psi0)
-      Descriptor = Descriptor + "5" +  DataTypeString() + "OverM3";
+      Descriptor = Descriptor + "5" + DataTypeString() + "OverM3";
   } else {
     Descriptor = Descriptor + DataTypeString();
   }
@@ -870,7 +870,7 @@ std::vector<double> GWFrames::Waveform::NormalizedAntisymmetry(std::vector<int> 
   for(unsigned int i_t=0; i_t<ntimes; ++i_t) {
     diff = 0.;
     norm = 0.;
-    for(int ell=2; ell<=ellMax; ++ell) {
+    for(int ell=std::abs(SpinWeight()); ell<=ellMax; ++ell) {
       if(LModesForAsymmetry.size()==0 || GWFrames::xINy(ell,LModesForAsymmetry)) {
         for(int m=-ell; m<=ell; ++m) {
           const complex<double> h_ell_m = Data(FindModeIndexWithoutError(ell,m), i_t);
@@ -1356,7 +1356,8 @@ GWFrames::Waveform& GWFrames::Waveform::TransformModesToRotatedFrame(const std::
   // Loop through each mode and do the rotation
   {
     int mode=1;
-    for(int l=std::abs(SpinWeight()); l<NModes; ++l) {
+    const int lmin = lm[0][0];
+    for(int l=lmin; l<NModes; ++l) {
       if(NModes<mode) { break; }
 
       // Use a vector of mode indices, in case the modes are out of

--- a/Code/Waveforms.cpp
+++ b/Code/Waveforms.cpp
@@ -1364,8 +1364,7 @@ GWFrames::Waveform& GWFrames::Waveform::TransformModesToRotatedFrame(const std::
   // Loop through each mode and do the rotation
   {
     int mode=1;
-    const int lmin = lm[0][0];
-    for(int l=lmin; l<NModes; ++l) {
+    for(int l=std::abs(SpinWeight()); l<NModes; ++l) {
       if(NModes<mode) { break; }
 
       // Use a vector of mode indices, in case the modes are out of

--- a/Code/Waveforms.cpp
+++ b/Code/Waveforms.cpp
@@ -663,6 +663,14 @@ std::string GWFrames::Waveform::DescriptorString() const {
       Descriptor = Descriptor + DataTypeString(); // hdot is independent of M
     else if(DataType()==Psi4)
       Descriptor = Descriptor + "M" + DataTypeString();
+    else if(DataType()==Psi3)
+      Descriptor = Descriptor + DataTypeString();
+    else if(DataType()==Psi2)
+      Descriptor = Descriptor + DataTypeString() + "OverM";
+    else if(DataType()==Psi1)
+      Descriptor = Descriptor + DataTypeString();
+    else if(DataType()==Psi0)
+      Descriptor = Descriptor + "M" + DataTypeString();
   } else {
     Descriptor = Descriptor + DataTypeString();
   }

--- a/Code/Waveforms.cpp
+++ b/Code/Waveforms.cpp
@@ -1792,7 +1792,7 @@ GWFrames::Waveform& GWFrames::Waveform::TransformToCoprecessingFrame(const std::
     // output of GSL.
     RoughInitialEllDirection = Quaternions::zHat;
   } else {
-    const Waveform Segment = SliceOfTimeIndicesWithEll2(0, NPointsForDeriv);
+    const Waveform Segment = SliceOfTimeIndices(0, NPointsForDeriv);
     RoughInitialEllDirection = Quaternions::Quaternion(Segment.AngularVelocityVector()[NPointsForDeriv/2]); // Using integer division
   }
   history << "this->TransformToCoprecessingFrame(" << StringForm(Lmodes) << ")\n#";
@@ -2094,7 +2094,7 @@ std::vector<Quaternions::Quaternion> GWFrames::Waveform::GetAlignmentsOfDecompos
   // Get direction of angular-velocity vector at each time step, in this frame
   const vector<Quaternion> omegaHat
     = Quaternions::inverse(frame)
-    * Quaternions::normalized(Quaternions::QuaternionArray(this->SliceOfTimesWithEll2().AngularVelocityVectorRelativeToInertial())) * frame;
+    * Quaternions::normalized(Quaternions::QuaternionArray(this->AngularVelocityVectorRelativeToInertial())) * frame;
 
   const vector<vector<double> > V_h = this->LLDominantEigenvector(Lmodes);
 
@@ -2109,7 +2109,7 @@ std::vector<Quaternions::Quaternion> GWFrames::Waveform::GetAlignmentsOfDecompos
     const Quaternion R_V_hi = Quaternions::sqrtOfRotor(-V_hi*Quaternions::zHat);
 
     // Now rotate Instant so that its z axis is aligned with V_f
-    Waveform Instant = this->SliceOfTimeIndicesWithEll2(i_t);
+    Waveform Instant = this->SliceOfTimeIndices(i_t);
     Instant.RotateDecompositionBasis(R_V_hi);
 
     // Get the phase of the (2,+/-2) modes after rotation
@@ -2185,7 +2185,7 @@ Quaternions::Quaternion GWFrames::Waveform::GetAlignmentOfDecompositionFrameToMo
   int i_t_fid = Quaternions::huntRight(t, t_fid);
   unsigned int i1 = (i_t_fid-5<0 ? 0 : i_t_fid-5);
   unsigned int i2 = (i1+11>int(t.size()) ? t.size() : i1+11);
-  const Waveform Region = (this->SliceOfTimeIndicesWithEll2(i1,i2)).TransformToInertialFrame();
+  const Waveform Region = (this->SliceOfTimeIndices(i1,i2)).TransformToInertialFrame();
   Quaternion omegaHat = Quaternion(Region.AngularVelocityVector()[i_t_fid-i1]).normalized();
   // omegaHat contains the components of that vector relative to the
   // inertial frame.  To get its components in this Waveform's

--- a/Code/Waveforms.cpp
+++ b/Code/Waveforms.cpp
@@ -664,13 +664,13 @@ std::string GWFrames::Waveform::DescriptorString() const {
     else if(DataType()==Psi4)
       Descriptor = Descriptor + "M" + DataTypeString();
     else if(DataType()==Psi3)
-      Descriptor = Descriptor + DataTypeString();
+      Descriptor = Descriptor + "2" + DataTypeString();
     else if(DataType()==Psi2)
-      Descriptor = Descriptor + DataTypeString() + "OverM";
+      Descriptor = Descriptor + "3" + DataTypeString() + "OverM";
     else if(DataType()==Psi1)
-      Descriptor = Descriptor + DataTypeString();
+      Descriptor = Descriptor + "4" + DataTypeString() + "OverM2";
     else if(DataType()==Psi0)
-      Descriptor = Descriptor + "M" + DataTypeString();
+      Descriptor = Descriptor + "5" +  DataTypeString() + "OverM3";
   } else {
     Descriptor = Descriptor + DataTypeString();
   }

--- a/Code/Waveforms.cpp
+++ b/Code/Waveforms.cpp
@@ -670,7 +670,7 @@ std::string GWFrames::Waveform::DescriptorString() const {
     else if(DataType()==hdot)
       Descriptor = Descriptor + DataTypeString(); // hdot is independent of M
     else if(DataType()==Psi4)
-      Descriptor = Descriptor + DataTypeString();
+      Descriptor = Descriptor + "M" + DataTypeString();
     else if(DataType()==Psi3)
       Descriptor = Descriptor + DataTypeString();
     else if(DataType()==Psi2)

--- a/Code/Waveforms.cpp
+++ b/Code/Waveforms.cpp
@@ -655,22 +655,30 @@ unsigned int GWFrames::Waveform::MaxNormIndex(const unsigned int SkipFraction) c
 // Return a descriptive string appropriate for a file name, like rhOverM.
 std::string GWFrames::Waveform::DescriptorString() const {
   std::string Descriptor = "";
-  if(RIsScaledOut()) Descriptor = "r";
+  if(RIsScaledOut()) {
+    if(DataType()==UnknownDataType or DataType()==h) Descriptor = "r";
+    else if(DataType()==hdot) Descriptor = "r";
+    else if(DataType()==Psi4) Descriptor = "r";
+    else if(DataType()==Psi3) Descriptor = "r2";
+    else if(DataType()==Psi2) Descriptor = "r3";
+    else if(DataType()==Psi1) Descriptor = "r4";
+    else if(DataType()==Psi0) Descriptor = "r5";
+  }
   if(MIsScaledOut()) {
     if(DataType()==UnknownDataType or DataType()==h)
       Descriptor = Descriptor + DataTypeString() + "OverM";
     else if(DataType()==hdot)
       Descriptor = Descriptor + DataTypeString(); // hdot is independent of M
     else if(DataType()==Psi4)
-      Descriptor = Descriptor + "M" + DataTypeString();
+      Descriptor = Descriptor + DataTypeString();
     else if(DataType()==Psi3)
-      Descriptor = Descriptor + "2" + DataTypeString();
+      Descriptor = Descriptor + DataTypeString();
     else if(DataType()==Psi2)
-      Descriptor = Descriptor + "3" + DataTypeString() + "OverM";
+      Descriptor = Descriptor + DataTypeString() + "OverM";
     else if(DataType()==Psi1)
-      Descriptor = Descriptor + "4" + DataTypeString() + "OverM2";
+      Descriptor = Descriptor + DataTypeString() + "OverM2";
     else if(DataType()==Psi0)
-      Descriptor = Descriptor + "5" + DataTypeString() + "OverM3";
+      Descriptor = Descriptor + DataTypeString() + "OverM3";
   } else {
     Descriptor = Descriptor + DataTypeString();
   }

--- a/Code/Waveforms.cpp
+++ b/Code/Waveforms.cpp
@@ -1930,6 +1930,7 @@ GWFrames::Waveform GWFrames::Waveform::Interpolate(const std::vector<double>& Ne
   }
 
   Waveform C;
+  C.spinweight = this->spinweight;
   C.history << HistoryStr()
             << "### *this = this->Interpolate(NewTime," << AllowTimesOutsideCurrentDomain << ");" << std::endl;
   C.t = NewTime;

--- a/Code/Waveforms.hpp
+++ b/Code/Waveforms.hpp
@@ -31,9 +31,9 @@ namespace GWFrames {
 
   enum WaveformFrameType { UnknownFrameType, Inertial, Coprecessing, Coorbital, Corotating };
   static const std::string WaveformFrameNames[5] = { "UnknownFrameType", "Inertial", "Coprecessing", "Coorbital", "Corotating" };
-  enum WaveformDataType { UnknownDataType, h, hdot, Psi4 };
-  static const std::string WaveformDataNames[4] = { "UnknownDataType", "h", "hdot", "Psi4" };
-  static const std::string WaveformDataNamesLaTeX[4] = { "\\mathrm{unknown data type}", "h", "\\dot{h}", "\\Psi_4" };
+  enum WaveformDataType { UnknownDataType, h, hdot, Psi4, Psi3, Psi2, Psi1, Psi0 };
+  static const std::string WaveformDataNames[8] = { "UnknownDataType", "h", "hdot", "Psi4", "Psi3", "Psi2", "Psi1", "Psi0" };
+  static const std::string WaveformDataNamesLaTeX[8] = { "\\mathrm{unknown data type}", "h", "\\dot{h}", "\\Psi_4", "\\Psi_3", "\\Psi_2", "\\Psi_1", "\\Psi_0" };
   const int WeightError = 1000;
 
   /// Object storing data and other information for a single waveform


### PR DESCRIPTION
Primarily adds support for extrapolation of all Weyl scalars. I also added an extra check in `Code/GWFrames/Extrapolation.py` that checks to make sure all the time columns are the same before running the extrapolation procedure. 

For testing purposes I added an input variable called EnforceQualityAssurance, which when set to false will progress the extrapolation even if the initial checks fail. I can remove this from the pull request if you don't want this in master. 