### PR TITLE
Add support for versioning

### DIFF
--- a/Code/SWIG/Extensions.py
+++ b/Code/SWIG/Extensions.py
@@ -274,7 +274,7 @@ def OutputToH5(W, FileName, FileWriteMode='w') :
     'rhOverM_Corotating_' or 'rPsi4_Aligned_'.
 
     """
-    from h5py import File
+    from h5py import File, special_dtype
     from GWFrames import UnknownDataType, h, hdot, Psi4
     # Add descriptive prefix to FileName
     FileName = __AddFileNamePrefix(W, FileName)
@@ -289,6 +289,8 @@ def OutputToH5(W, FileName, FileWriteMode='w') :
         F.attrs['OutputFormatVersion'] = 'GWFrames_v2'
         F.create_dataset("History", data = W.HistoryStr() + 'OutputToH5(W, {0})\n'.format(FileName))
         F.create_dataset("Time", data=W.T().tolist(), compression="gzip", shuffle=True)
+        if(len(W.VersionHist())>0) :
+            F.create_dataset("VersionHist", (1,2), data = W.VersionHist(), dtype=special_dtype(vlen=bytes))
         if(len(W.Frame())>0) :
             F.create_dataset("Frame", data=[[r[0], r[1], r[2], r[3]] for r in W.Frame()])
         else :

--- a/Code/SWIG/GWFrames.i
+++ b/Code/SWIG/GWFrames.i
@@ -60,6 +60,8 @@
 //// Make sure std::complex numbers are dealt with appropriately
 %include <std_complex.i>
 
+%include <std_pair.i>
+
 
 /////////////////////////////////////////////////////////////////////
 //// The doxygen-generated documentation is added with this line ////

--- a/Code/SWIG/Utilities.i
+++ b/Code/SWIG/Utilities.i
@@ -12,6 +12,8 @@
 %include "../Utilities.hpp"
 namespace std {
   %template(_vectorM) vector<GWFrames::Matrix>;
+  %template() pair<string,string>;
+  %template() vector<pair<string,string> >;
 };
 %extend GWFrames::Matrix {
   // Print the Matrix nicely at the prompt

--- a/Code/Waveforms.cpp
+++ b/Code/Waveforms.cpp
@@ -90,7 +90,7 @@ std::string StringForm(const std::vector<int>& Lmodes) {
 
 /// Default constructor for an empty object
 GWFrames::Waveform::Waveform() :
-  spinweight(-2), boostweight(-1), history(""), t(0),frame(0), frameType(GWFrames::UnknownFrameType),
+  spinweight(-2), boostweight(-1), history(""), versionHist(), t(0), frame(0), frameType(GWFrames::UnknownFrameType),
   dataType(GWFrames::UnknownDataType), rIsScaledOut(false), mIsScaledOut(false), lm(), data()
 {
   {
@@ -117,8 +117,9 @@ GWFrames::Waveform::Waveform() :
 
 /// Copy constructor
 GWFrames::Waveform::Waveform(const GWFrames::Waveform& a) :
-  spinweight(a.spinweight), boostweight(a.boostweight), history(a.history.str()), t(a.t), frame(a.frame), frameType(a.frameType),
-  dataType(a.dataType), rIsScaledOut(a.rIsScaledOut), mIsScaledOut(a.mIsScaledOut), lm(a.lm), data(a.data)
+  spinweight(a.spinweight), boostweight(a.boostweight), history(a.history.str()), versionHist(a.versionHist),
+  t(a.t), frame(a.frame), frameType(a.frameType), dataType(a.dataType), rIsScaledOut(a.rIsScaledOut),
+  mIsScaledOut(a.mIsScaledOut), lm(a.lm), data(a.data)
 {
   /// Simply copies all fields in the input object to the constructed
   /// object, including history
@@ -127,7 +128,7 @@ GWFrames::Waveform::Waveform(const GWFrames::Waveform& a) :
 
 /// Constructor from data file
 GWFrames::Waveform::Waveform(const std::string& FileName, const std::string& DataFormat) :
-  spinweight(-2), boostweight(-1), history(""), t(0), frame(0), frameType(GWFrames::UnknownFrameType),
+  spinweight(-2), boostweight(-1), history(""), versionHist(), t(0), frame(0), frameType(GWFrames::UnknownFrameType),
   dataType(GWFrames::UnknownDataType), rIsScaledOut(false), mIsScaledOut(false), lm(), data()
 {
   ///
@@ -269,6 +270,7 @@ GWFrames::Waveform& GWFrames::Waveform::operator=(const GWFrames::Waveform& a) {
   history.str(a.history.str());
   history.clear();
   history.seekp(0, ios_base::end);
+  versionHist = a.versionHist;
   t = a.t;
   frame = a.frame;
   frameType = a.frameType;
@@ -288,6 +290,7 @@ GWFrames::Waveform GWFrames::Waveform::CopyWithoutData() const {
   that.history.str((*this).history.str());
   that.history.clear();
   that.history.seekp(0, ios_base::end);
+  that.versionHist = (*this).versionHist;
   that.frameType = (*this).frameType;
   that.dataType = (*this).dataType;
   that.rIsScaledOut = (*this).rIsScaledOut;
@@ -532,6 +535,7 @@ void GWFrames::Waveform::swap(GWFrames::Waveform& b) {
   { const string historyb=b.history.str(); b.history.str(history.str()); history.str(historyb); }
   history.seekp(0, ios_base::end);
   b.history.seekp(0, ios_base::end);
+  versionHist.swap(b.versionHist);
   t.swap(b.t);
   frame.swap(b.frame);
   { const GWFrames::WaveformFrameType bType=b.frameType; b.frameType=frameType; frameType=bType; }
@@ -3068,6 +3072,7 @@ GWFrames::Waveform GWFrames::Waveform::Hybridize(const GWFrames::Waveform& B, co
             << "#### A.history.str():\n" << A.history.str()
             << "#### B.history.str():\n" << B.history.str()
             << "#### End of old histories from `Hybridize`" << std::endl;
+  C.versionHist = A.versionHist;
   C.t = GWFrames::Union(A.t, B.t, tMinStep);
   // We'll assume that A.lm==B.lm, though we'll account for disordering below
   C.lm = A.lm;
@@ -3343,6 +3348,7 @@ GWFrames::Waveform GWFrames::Waveform::Translate(const std::vector<std::vector<d
   const Waveform& A = *this;
   Waveform B = A.CopyWithoutData();
   B.history << "*this = this->.Translate(...);"<< std::endl;
+  B.versionHist = A.versionHist;
   B.frame = std::vector<Quaternions::Quaternion>(0);
   B.frameType = GWFrames::Inertial;
   B.lm = A.lm;

--- a/Code/Waveforms.hpp
+++ b/Code/Waveforms.hpp
@@ -43,6 +43,7 @@ namespace GWFrames {
     int spinweight;
     int boostweight;
     std::stringstream history;
+    std::vector<std::pair<std::string,std::string> > versionHist;
     std::vector<double> t;
     std::vector<Quaternions::Quaternion> frame;
     WaveformFrameType frameType;
@@ -81,6 +82,7 @@ namespace GWFrames {
     inline Waveform& SetBoostWeight(const int NewBoostWeight) { boostweight=NewBoostWeight; return *this; }
     inline Waveform& AppendHistory(const std::string& Hist) { history << Hist; return *this; }
     inline Waveform& SetHistory(const std::string& Hist) { history.str(Hist); history.seekp(0, std::ios_base::end); return *this; }
+    inline Waveform& SetVersionHist(const std::vector<std::pair<std::string,std::string> >& VerHist) { versionHist = VerHist; return *this; }
     inline Waveform& SetT(const std::vector<double>& a) { t = a; return *this; }
     inline Waveform& SetTime(const std::vector<double>& a) { t = a; return *this; }
     inline Waveform& SetFrame(const std::vector<Quaternions::Quaternion>& a) { frame = a; return *this; }
@@ -101,6 +103,7 @@ namespace GWFrames {
     inline int BoostWeight() const { return boostweight; }
     inline std::string HistoryStr() const { return history.str(); }
     inline std::stringstream& HistoryStream() { return history; }
+    inline std::vector<std::pair<std::string,std::string> > VersionHist() const { return versionHist; }
     inline int FrameType() const { return frameType; }
     inline int DataType() const { return dataType; }
     inline std::string FrameTypeString() const { return WaveformFrameNames[frameType]; }


### PR DESCRIPTION
If the source H5 file has a `VersionHist.ver` dataset, then it will not fail the file validation step and it will copy `VersionHist.ver` over to the extrapolated files.

I am submitting this PR for discussion in regards to the other updates you want to do as well.